### PR TITLE
Add auto-approve workflow for feature/, bugfix/, claude/ branches

### DIFF
--- a/.github/workflows/auto_approve_prs.yml
+++ b/.github/workflows/auto_approve_prs.yml
@@ -1,0 +1,24 @@
+name: Auto Approve PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.head_ref, 'feature/') ||
+      startsWith(github.head_ref, 'bugfix/') ||
+      startsWith(github.head_ref, 'claude/')
+    steps:
+      - name: Approve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review "$PR_URL" --approve


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow to automatically approve pull requests from `feature/`, `bugfix/`, and `claude/` branches, matching the pattern established in AppodealSDK-iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)